### PR TITLE
:sparkles: Jlink command line options configuration

### DIFF
--- a/jlink-gradle/src/main/kotlin/com/ryandens/jlink/JlinkJreExtension.kt
+++ b/jlink-gradle/src/main/kotlin/com/ryandens/jlink/JlinkJreExtension.kt
@@ -1,6 +1,7 @@
 package com.ryandens.jlink
 
 import org.gradle.api.provider.ListProperty
+import org.gradle.api.provider.Property
 
 abstract class JlinkJreExtension {
 
@@ -9,4 +10,20 @@ abstract class JlinkJreExtension {
     }
 
     abstract val modules: ListProperty<String>
+
+    abstract val compress: Property<Int>
+
+    abstract val stripDebug: Property<Boolean>
+
+    abstract val noHeaderFiles: Property<Boolean>
+
+    abstract val noManPages: Property<Boolean>
+
+    abstract val endian: Property<Endian>
+
+    enum class Endian {
+        LITTLE,
+        BIG,
+        NATIVE,
+    }
 }

--- a/jlink-gradle/src/main/kotlin/com/ryandens/jlink/JlinkJrePlugin.kt
+++ b/jlink-gradle/src/main/kotlin/com/ryandens/jlink/JlinkJrePlugin.kt
@@ -16,12 +16,22 @@ class JlinkJrePlugin : Plugin<Project> {
         project.pluginManager.apply(JavaPlugin::class.java)
         val extension = project.extensions.create(JlinkJreExtension.NAME, JlinkJreExtension::class.java).apply {
             modules.convention(listOf("java.base"))
+            compress.convention(2)
+            stripDebug.convention(true)
+            noHeaderFiles.convention(true)
+            noManPages.convention(true)
+            endian.convention(JlinkJreExtension.Endian.NATIVE)
         }
 
         val jlinkJreTask = project.tasks.register(JLINK_JRE_TASK_NAME, JlinkJreTask::class.java)
 
         project.tasks.withType(JlinkJreTask::class.java).configureEach {
             it.modules.set(extension.modules)
+            it.compress.set(extension.compress)
+            it.stripDebug.set(extension.stripDebug)
+            it.noHeaderFiles.set(extension.noHeaderFiles)
+            it.noManPages.set(extension.noManPages)
+            it.endian.set(extension.endian)
         }
 
         project.configurations.create("jlinkJre") {


### PR DESCRIPTION
Enable jlink task and plugin to be configured with its command line options. Provide sensible defaults for most users