### PR TITLE
Make it possible to apply the Temurin Repository via settings.gradle

### DIFF
--- a/temurin-binaries-repository/src/main/kotlin/com/ryandens/temurin/TemurinBinariesRepository.kt
+++ b/temurin-binaries-repository/src/main/kotlin/com/ryandens/temurin/TemurinBinariesRepository.kt
@@ -2,26 +2,38 @@ package com.ryandens.temurin
 
 import org.gradle.api.Plugin
 import org.gradle.api.Project
+import org.gradle.api.artifacts.dsl.RepositoryHandler
+import org.gradle.api.initialization.Settings
 import java.net.URI
 
-class TemurinBinariesRepository : Plugin<Project> {
-    override fun apply(project: Project) {
-        project.repositories.apply {
-            exclusiveContent { exclusiveContentRepository ->
-                exclusiveContentRepository.forRepository {
-                    ivy { ivyRepository ->
-                        ivyRepository.url = URI.create("https://github.com/adoptium/")
-                        ivyRepository.patternLayout { layout ->
-                            layout.artifact("[organisation]/releases/download/[revision]/[module].[ext]")
-                        }
-                        ivyRepository.metadataSources { metadataSources ->
-                            metadataSources.artifact()
-                        }
+class TemurinBinariesRepository : Plugin<Any> {
+    override fun apply(target: Any) {
+        if (target is Project) {
+            apply(target)
+        } else if (target is Settings) {
+            apply(target)
+        }
+    }
+
+    private fun apply(project: Project) = project.repositories.addRepository()
+
+    private fun apply(settings: Settings) = settings.dependencyResolutionManagement.repositories.addRepository()
+
+    private fun RepositoryHandler.addRepository() {
+        exclusiveContent { exclusiveContentRepository ->
+            exclusiveContentRepository.forRepository {
+                ivy { ivyRepository ->
+                    ivyRepository.url = URI.create("https://github.com/adoptium/")
+                    ivyRepository.patternLayout { layout ->
+                        layout.artifact("[organisation]/releases/download/[revision]/[module].[ext]")
+                    }
+                    ivyRepository.metadataSources { metadataSources ->
+                        metadataSources.artifact()
                     }
                 }
-                exclusiveContentRepository.filter { filter ->
-                    filter.includeGroupByRegex("^temurin([1-9]*)-binaries")
-                }
+            }
+            exclusiveContentRepository.filter { filter ->
+                filter.includeGroupByRegex("^temurin([1-9]*)-binaries")
             }
         }
     }


### PR DESCRIPTION
Projects that use dependencyResolutionManagement will want to apply the plugin on their Settings, rather than on individual Projects.