### PR TITLE
Support for typical JDK 25 installations and explicit handling for JEP-493

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -27,6 +27,7 @@ jobs:
           java-version: |
             17
             21
+            25
 
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v6.1.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/setup-java@v5.2.0
         with:
           distribution: temurin
-          java-version: 21
+          java-version: 25
       - name: Set up Gradle
         uses: gradle/actions/setup-gradle@v6.1.0
         with:

--- a/build-logic/src/main/kotlin/com.ryandens.jlink.plugin-conventions.gradle.kts
+++ b/build-logic/src/main/kotlin/com.ryandens.jlink.plugin-conventions.gradle.kts
@@ -17,7 +17,7 @@ repositories {
 
 java {
     toolchain {
-        languageVersion.set(JavaLanguageVersion.of(21))
+        languageVersion.set(JavaLanguageVersion.of(25))
     }
 }
 
@@ -45,7 +45,7 @@ gradlePlugin {
 }
 
 group = "com.ryandens"
-version = "0.6.0"
+version = "0.7.0"
 
 spotless {
     kotlin {

--- a/jlink-gradle/src/main/kotlin/com/ryandens/jlink/tasks/JlinkJreTask.kt
+++ b/jlink-gradle/src/main/kotlin/com/ryandens/jlink/tasks/JlinkJreTask.kt
@@ -54,6 +54,7 @@ abstract class JlinkJreTask : AbstractExecTask<JlinkJreTask> {
 
     @get:InputDirectory
     @get:PathSensitive(PathSensitivity.ABSOLUTE)
+    @get:Optional
     abstract val modulePath: DirectoryProperty
 
     @get:OutputDirectory
@@ -73,7 +74,12 @@ abstract class JlinkJreTask : AbstractExecTask<JlinkJreTask> {
         modules.convention(listOf("java.base"))
         modulePath.convention(
             javaCompiler.map {
-                it.metadata.installationPath.dir("jmods")
+                if (it.metadata.languageVersion.asInt() >= 24) {
+                    // on JDK 24 and up, no jmods dir is needed due to https://openjdk.org/jeps/493
+                    null
+                } else {
+                    it.metadata.installationPath.dir("jmods")
+                }
             },
         )
 

--- a/jlink-gradle/src/main/kotlin/com/ryandens/jlink/tasks/JlinkJreTask.kt
+++ b/jlink-gradle/src/main/kotlin/com/ryandens/jlink/tasks/JlinkJreTask.kt
@@ -71,7 +71,11 @@ abstract class JlinkJreTask : AbstractExecTask<JlinkJreTask> {
         // use it as our default for the property
         javaCompiler.convention(defaultJlinkTool)
         modules.convention(listOf("java.base"))
-        modulePath.convention(javaCompiler.map { it.metadata.installationPath.dir("jmods") })
+        modulePath.convention(
+            javaCompiler.map {
+                it.metadata.installationPath.dir("jmods")
+            },
+        )
 
         outputDirectory.convention(project.layout.buildDirectory.dir("jlink-jre"))
     }
@@ -92,10 +96,16 @@ abstract class JlinkJreTask : AbstractExecTask<JlinkJreTask> {
 
         args =
             buildList {
+                if (modulePath.isPresent) {
+                    addAll(
+                        listOf(
+                            "--module-path",
+                            modulePath.get().asFile.absolutePath,
+                        ),
+                    )
+                }
                 addAll(
                     listOf(
-                        "--module-path",
-                        modulePath.get().asFile.absolutePath,
                         "--add-modules",
                         modules.get().joinToString(","),
                         "--output",

--- a/jlink-gradle/src/test/kotlin/com/ryandens/jlink/JlinkJrePluginTest.kt
+++ b/jlink-gradle/src/test/kotlin/com/ryandens/jlink/JlinkJrePluginTest.kt
@@ -3,8 +3,8 @@ package com.ryandens.jlink
 import com.ryandens.jlink.tasks.JlinkJreTask
 import org.gradle.testfixtures.ProjectBuilder
 import kotlin.test.Test
-import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
 
 /**
  * A simple unit test for the 'com.ryandens.jlink-jre' plugin.
@@ -18,11 +18,6 @@ class JlinkJrePluginTest {
         // Verify the result
         val jlinkJreTask = project.tasks.getByName("jlinkJre") as JlinkJreTask
         assertNotNull(jlinkJreTask)
-        assertEquals(
-            "jmods",
-            jlinkJreTask.modulePath
-                .get()
-                .asFile.name,
-        )
+        assertTrue(jlinkJreTask.modulePath.isPresent.not())
     }
 }


### PR DESCRIPTION
- **:arrow_up: upgrade to java 25 for building and testing this project**
- **:alembic: allow module path to be unset**
- **:sparkles: support JDK 24 and up in the context of JEP 493**
