### PR TITLE
:sparkles: Minimal changes to be compatible with a jib-like configuration cache compatible plugin

### DIFF
--- a/build-logic/src/main/kotlin/com.ryandens.jlink.plugin-conventions.gradle.kts
+++ b/build-logic/src/main/kotlin/com.ryandens.jlink.plugin-conventions.gradle.kts
@@ -54,6 +54,9 @@ spotless {
     kotlinGradle {
         ktlint()
     }
+    java {
+        googleJavaFormat()
+    }
 }
 
 testing {

--- a/build-logic/src/main/kotlin/com.ryandens.jlink.plugin-conventions.gradle.kts
+++ b/build-logic/src/main/kotlin/com.ryandens.jlink.plugin-conventions.gradle.kts
@@ -45,7 +45,7 @@ gradlePlugin {
 }
 
 group = "com.ryandens"
-version = "0.7.0"
+version = "0.8.0"
 
 spotless {
     kotlin {

--- a/jlink-jib/src/main/java/com/ryandens/jlink/jib/Configuration.java
+++ b/jlink-jib/src/main/java/com/ryandens/jlink/jib/Configuration.java
@@ -4,6 +4,7 @@ import java.nio.file.attribute.PosixFilePermission;
 import javax.inject.Inject;
 import org.gradle.api.Project;
 import org.gradle.api.file.DirectoryProperty;
+import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.provider.SetProperty;
 import org.gradle.api.tasks.Input;
 
@@ -12,17 +13,29 @@ public class Configuration {
   private final DirectoryProperty jlinkJre;
   private final SetProperty<PosixFilePermission> posixPermissions;
 
+  /** Used by jib plugin */
   @Inject
   public Configuration(final Project project) {
-    jlinkJre = project.getObjects().directoryProperty();
-    posixPermissions = project.getObjects().setProperty(PosixFilePermission.class);
+    this(project.getObjects());
   }
 
+  /** Used by tiny-jib */
+  public Configuration(final ObjectFactory objectFactory) {
+    jlinkJre = objectFactory.directoryProperty();
+    posixPermissions = objectFactory.setProperty(PosixFilePermission.class);
+  }
+
+  /**
+   * @return the JRE created by jlink. This is used as the entrypoint for the container.
+   */
   @Input
   DirectoryProperty getJlinkJre() {
     return jlinkJre;
   }
 
+  /**
+   * @return the file permissions to set for the javaagent files being added to the image layer.
+   */
   @Input
   SetProperty<PosixFilePermission> getPosixPermissions() {
     return posixPermissions;

--- a/jlink-jib/src/main/java/com/ryandens/jlink/jib/Configuration.java
+++ b/jlink-jib/src/main/java/com/ryandens/jlink/jib/Configuration.java
@@ -1,0 +1,30 @@
+package com.ryandens.jlink.jib;
+
+import java.nio.file.attribute.PosixFilePermission;
+import javax.inject.Inject;
+import org.gradle.api.Project;
+import org.gradle.api.file.DirectoryProperty;
+import org.gradle.api.provider.SetProperty;
+import org.gradle.api.tasks.Input;
+
+public class Configuration {
+
+  private final DirectoryProperty jlinkJre;
+  private final SetProperty<PosixFilePermission> posixPermissions;
+
+  @Inject
+  public Configuration(final Project project) {
+    jlinkJre = project.getObjects().directoryProperty();
+    posixPermissions = project.getObjects().setProperty(PosixFilePermission.class);
+  }
+
+  @Input
+  DirectoryProperty getJlinkJre() {
+    return jlinkJre;
+  }
+
+  @Input
+  SetProperty<PosixFilePermission> getPosixPermissions() {
+    return posixPermissions;
+  }
+}

--- a/jlink-jib/src/main/kotlin/com/ryandens/jlink/jib/JlinkJibPlugin.kt
+++ b/jlink-jib/src/main/kotlin/com/ryandens/jlink/jib/JlinkJibPlugin.kt
@@ -12,29 +12,33 @@ import com.google.cloud.tools.jib.gradle.extension.JibGradlePluginExtension
 import com.google.cloud.tools.jib.plugins.extension.ExtensionLogger
 import com.ryandens.jlink.JlinkJrePlugin
 import com.ryandens.jlink.tasks.JlinkJreTask
+import org.gradle.api.Action
+import org.gradle.api.GradleException
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import java.nio.file.attribute.PosixFilePermission
 import java.util.Optional
 
 class JlinkJibPlugin :
-    JibGradlePluginExtension<Void>,
+    JibGradlePluginExtension<Configuration>,
     Plugin<Project> {
-    override fun getExtraConfigType(): Optional<Class<Void>> = Optional.empty()
+    override fun getExtraConfigType(): Optional<Class<Configuration>> = Optional.of(Configuration::class.java)
 
     override fun extendContainerBuildPlan(
-        buildPlan: ContainerBuildPlan?,
-        properties: MutableMap<String, String>?,
-        extraConfig: Optional<Void>?,
+        buildPlan: ContainerBuildPlan,
+        properties: MutableMap<String, String>,
+        extraConfig: Optional<Configuration>,
         gradleData: GradleData?,
         logger: ExtensionLogger?,
     ): ContainerBuildPlan {
-        checkNotNull(buildPlan)
         val entrypoint = checkNotNull(buildPlan.entrypoint)
 
-        val project = gradleData!!.project
-        val jlinkJibPluginExtension = project.extensions.getByType(JlinkJibPluginExtension::class.java)
-        val jlinkJreOutput = jlinkJibPluginExtension.jlinkJre
+        if (extraConfig.isEmpty) {
+            throw GradleException("Jlink plugin applied to an entrypoint must be configured")
+        }
+
+        val configuration = extraConfig.get()
+        val jlinkJreOutput = configuration.jlinkJre
         val jreInstallationDirectory = "/usr/lib/jvm/jlink-jre/"
         val planBuilder = buildPlan.toBuilder()
 
@@ -52,7 +56,7 @@ class JlinkJibPlugin :
                     FileEntry(
                         it.toPath(),
                         AbsoluteUnixPath.get("$jreInstallationDirectory${it.toRelativeString(jlinkJreOutput.get().asFile)}"),
-                        FilePermissions.fromPosixFilePermissions(jlinkJibPluginExtension.jrePosixFilePermissions.get()),
+                        FilePermissions.fromPosixFilePermissions(configuration.posixPermissions.get()),
                         FileEntriesLayer.DEFAULT_MODIFICATION_TIME,
                     )
                 }.toMutableList()
@@ -89,11 +93,20 @@ class JlinkJibPlugin :
             }
         }
 
+        val jlinkJibPluginExtension = project.extensions.getByType(JlinkJibPluginExtension::class.java)
+        jlinkJibPluginExtension.jrePosixFilePermissions
+
         // configure the jib extension
         val jibExtension: JibExtension? = project.extensions.findByType(JibExtension::class.java)
         jibExtension?.pluginExtensions { extensionParametersSpec ->
-            extensionParametersSpec.pluginExtension {
-                it.implementation = "com.ryandens.jlink.jib.JlinkJibPlugin"
+            extensionParametersSpec.pluginExtension { extension ->
+                extension.implementation = "com.ryandens.jlink.jib.JlinkJibPlugin"
+                extension.configuration(
+                    Action<Configuration> { configuration ->
+                        configuration.jlinkJre.set(jlinkJibPluginExtension.jlinkJre)
+                        configuration.posixPermissions.set(jlinkJibPluginExtension.jrePosixFilePermissions)
+                    },
+                )
             }
         }
     }


### PR DESCRIPTION
- **:art: formatting for java source**
- **:sparkles: use jib configuration rather than relying on Gradle project APIs at task execution time**
- **:bug: fix bugs with Configuration class, allowing instantiation by either plugin**
