### PR TITLE
Add TestLens instrumentation to CI build

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -34,5 +34,8 @@ jobs:
         with:
           cache-read-only: false
 
+      - name: Setup TestLens
+        uses: testlens-app/setup-testlens@v1
+
       - name: Execute Gradle build
         run: ./gradlew build


### PR DESCRIPTION
## Summary
Sets up the [setup-testlens](https://github.com/testlens-app/setup-testlens) GitHub Action now that the TestLens GitHub App is installed on this repo.

- Adds `testlens-app/setup-testlens@v1` to the `build` job in `.github/workflows/gradle.yml`, positioned **after** `gradle/actions/setup-gradle` and **before** `./gradlew build` as the docs require. The action writes a Gradle init script that instruments all `Test` tasks.

## Notes
- Scoped to the `Validate` workflow (PRs + pushes to `main`) — where test intelligence is most useful. The tag-triggered `release.yml` was left untouched; happy to add it there too if you want release builds instrumented.
- The `build` job runs on both `ubuntu-latest` and `windows-latest`; the action is shell-based and runs on both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add TestLens instrumentation to the CI build job
> Adds a `testlens-app/setup-testlens@v1` step to [gradle.yml](.github/workflows/gradle.yml) before the Gradle build executes. This runs on both `ubuntu-latest` and `windows-latest` matrix runners.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6ed902f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->